### PR TITLE
support apple silicon MPS

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,12 @@
+name: dsd
+channels:
+  - defaults
+dependencies:
+  - python=3.10
+  - torchvision
+  - pytorch=1.12.1
+  - nomkl
+  - torchaudio
+prefix: /Users/achan/opt/anaconda3/envs/dsd
+variables:
+  PYTORCH_ENABLE_MPS_FALLBACK: 1

--- a/helpers/animation.py
+++ b/helpers/animation.py
@@ -10,6 +10,8 @@ import pathlib
 import os
 import pandas as pd
 
+from .device import choose_torch_device
+
 def check_is_number(value):
     float_pattern = r'^(?=.)([+-]?([0-9]*)(\.([0-9]+))?)$'
     return re.match(float_pattern, value)
@@ -162,7 +164,7 @@ def warpMatrix(W, H, theta, phi, gamma, scale, fV):
 
     return M33, sideLength
 
-def anim_frame_warp(prev, args, anim_args, keys, frame_idx, depth_model=None, depth=None, device='cuda'):
+def anim_frame_warp(prev, args, anim_args, keys, frame_idx, depth_model=None, depth=None, device=choose_torch_device()):
     if isinstance(prev, np.ndarray):
         prev_img_cv2 = prev
     else:
@@ -226,7 +228,8 @@ def anim_frame_warp_3d(device, prev_img_cv2, depth, anim_args, keys, frame_idx):
     ]
     rot_mat = p3d.euler_angles_to_matrix(torch.tensor(rotate_xyz, device=device), "XYZ").unsqueeze(0)
     result = transform_image_3d(device, prev_img_cv2, depth, rot_mat, translate_xyz, anim_args)
-    torch.cuda.empty_cache()
+    if device == 'cuda':
+        torch.cuda.empty_cache()
     return result
 
 def transform_image_3d(device, prev_img_cv2, depth_tensor, rot_mat, translate, anim_args):

--- a/helpers/conditioning.py
+++ b/helpers/conditioning.py
@@ -9,6 +9,8 @@ from IPython import display
 from sklearn.cluster import KMeans
 import torchvision.transforms.functional as TF
 
+from helpers.device import choose_torch_device
+
 ###
 # Loss functions
 ###
@@ -144,7 +146,7 @@ def get_color_palette(root, n_colors, target, verbose=False):
     # color_list = color_list[color_indexes]
     return color_list, color_counts
 
-def make_rgb_color_match_loss(root, target, n_colors, ignore_sat_weight=None, img_shape=None, device='cuda:0'):
+def make_rgb_color_match_loss(root, target, n_colors, ignore_sat_weight=None, img_shape=None, device=choose_torch_device()):
     """
     target (tensor): Image sample (values from -1 to 1) to extract the color palette
     n_colors (int): Number of colors in the color palette

--- a/helpers/depth.py
+++ b/helpers/depth.py
@@ -121,7 +121,9 @@ class DepthModel():
             except:
                 print(f"  exception encountered, falling back to pure MiDaS")
                 use_adabins = False
-            torch.cuda.empty_cache()
+            
+            if self.device == torch.device("cuda"):
+                torch.cuda.empty_cache()
 
         if self.midas_model is not None:
             # convert image from 0->255 uint8 to 0->1 float for feeding to MiDaS
@@ -142,7 +144,9 @@ class DepthModel():
                 align_corners=False,
             ).squeeze()
             midas_depth = midas_depth.cpu().numpy()
-            torch.cuda.empty_cache()
+
+            if self.device == torch.device("cuda"):
+                torch.cuda.empty_cache()
 
             # MiDaS makes the near values greater, and the far values lesser. Let's reverse that and try to align with AdaBins a bit better.
             midas_depth = np.subtract(50.0, midas_depth)

--- a/helpers/device.py
+++ b/helpers/device.py
@@ -1,0 +1,9 @@
+import torch
+from torch import autocast
+
+def choose_torch_device() -> str:
+    if torch.cuda.is_available():
+        return 'cuda'
+    if hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
+        return 'mps'
+    return 'cpu'

--- a/helpers/model_load.py
+++ b/helpers/model_load.py
@@ -1,9 +1,11 @@
 import os
 import torch
 
+from .device import choose_torch_device
+
 # Decodes the image without passing through the upscaler. The resulting image will be the same size as the latent
 # Thanks to Kevin Turner (https://github.com/keturn) we have a shortcut to look at the decoded image!
-def make_linear_decode(model_version, device='cuda:0'):
+def make_linear_decode(model_version, device=choose_torch_device()):
     v1_4_rgb_latent_factors = [
         #   R       G       B
         [ 0.298,  0.207,  0.208],  # L1
@@ -183,10 +185,9 @@ def load_model(root, load_on_run_all=True, check_sha256=True):
         except:
             print("..could not verify model integrity")
 
-    def load_model_from_config(config, ckpt, verbose=False, device='cuda', half_precision=True,print_flag=False):
-        map_location = "cuda" # ["cpu", "cuda"]
+    def load_model_from_config(config, ckpt, verbose=False, device=choose_torch_device(), half_precision=True,print_flag=False):
         print(f"..loading model")
-        pl_sd = torch.load(ckpt, map_location=map_location)
+        pl_sd = torch.load(ckpt, map_location='cpu')
         if "global_step" in pl_sd:
             if print_flag:
                 print(f"Global Step: {pl_sd['global_step']}")
@@ -211,7 +212,7 @@ def load_model(root, load_on_run_all=True, check_sha256=True):
     if load_on_run_all and ckpt_valid:
         local_config = OmegaConf.load(f"{ckpt_config_path}")
         model = load_model_from_config(local_config, f"{ckpt_path}", half_precision=root.half_precision)
-        device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+        device = choose_torch_device()
         model = model.to(device)
 
     autoencoder_version = "sd-v1" #TODO this will be different for different models

--- a/helpers/model_wrap.py
+++ b/helpers/model_wrap.py
@@ -119,6 +119,7 @@ class CFGDenoiserWithGrad(CompVisDenoiser):
             x_in = torch.cat([x] * 2)
             sigma_in = torch.cat([sigma] * 2)
 
+            # import pdb; pdb.set_trace()
             denoised = self.inner_model(x_in, sigma_in, cond=cond, **kwargs)
             uncond_x0, cond_x0 = denoised.chunk(2)
             x0_pred = uncond_x0 + (cond_x0 - uncond_x0) * cond_scale

--- a/helpers/rank_images.py
+++ b/helpers/rank_images.py
@@ -9,12 +9,14 @@ import torch
 from simulacra_fit_linear_model import AestheticMeanPredictionLinearModel
 from CLIP import clip
 
+from .device import choose_torch_device
+
 parser = ArgumentParser()
 parser.add_argument("directory")
 parser.add_argument("-t", "--top-n", default=50)
 args = parser.parse_args()
 
-device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
+device = torch.device(choose_torch_device())
 
 clip_model_name = 'ViT-B/16'
 clip_model = clip.load(clip_model_name, jit=False, device=device)[0]

--- a/helpers/simulacra_compute_embeddings.py
+++ b/helpers/simulacra_compute_embeddings.py
@@ -17,6 +17,7 @@ from tqdm import tqdm
 
 from CLIP import clip
 
+from .device import choose_torch_device
 
 class SimulacraDataset(data.Dataset):
     """Simulacra dataset
@@ -69,7 +70,7 @@ def main():
     if args.device:
         device = torch.device(device)
     else:
-        device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+        device = torch.device(choose_torch_device())
     print('Using device:', device)
 
     clip_model, clip_tf = clip.load(args.clip_model, device=device, jit=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,12 +15,16 @@ numexpr
 omegaconf
 opencv-python
 pandas
+psutil
 pytorch_lightning==1.7.7
 resize-right
 scikit-image
 scikit-learn
 timm
+torch
+torchaudio
 torchdiffeq
+torchvision
 transformers==4.19.2
 albumentations
 more_itertools

--- a/src/clip/clip.py
+++ b/src/clip/clip.py
@@ -13,6 +13,8 @@ from tqdm import tqdm
 from .model import build_model
 from .simple_tokenizer import SimpleTokenizer as _Tokenizer
 
+from helpers.device import choose_torch_device
+
 try:
     from torchvision.transforms import InterpolationMode
     BICUBIC = InterpolationMode.BICUBIC
@@ -91,7 +93,7 @@ def available_models() -> List[str]:
     return list(_MODELS.keys())
 
 
-def load(name: str, device: Union[str, torch.device] = "cuda" if torch.cuda.is_available() else "cpu", jit: bool = False, download_root: str = None):
+def load(name: str, device: Union[str, torch.device] = choose_torch_device(), jit: bool = False, download_root: str = None):
     """Load a CLIP model
 
     Parameters

--- a/src/infer.py
+++ b/src/infer.py
@@ -12,6 +12,7 @@ import model_io
 import utils
 from adabins import UnetAdaptiveBins
 
+from helpers.device import choose_torch_device
 
 def _is_pil_image(img):
     return isinstance(img, Image.Image)
@@ -64,7 +65,7 @@ class ToTensor(object):
 
 
 class InferenceHelper:
-    def __init__(self, models_path, dataset='nyu', device='cuda:0'):
+    def __init__(self, models_path, dataset='nyu', device=choose_torch_device()):
         self.toTensor = ToTensor()
         self.device = device
         if dataset == 'nyu':

--- a/src/k_diffusion/sampling.py
+++ b/src/k_diffusion/sampling.py
@@ -439,12 +439,14 @@ def sample_dpm_adaptive(model, x, sigma_min, sigma_max, extra_args=None, callbac
 @torch.no_grad()
 def sample_dpmpp_2s_ancestral(model, x, sigmas, extra_args=None, callback=None, disable=None, eta=1., s_noise=1.):
     """Ancestral sampling with DPM-Solver++(2S) second-order steps."""
+    print("sample_dpmpp_2s_ancestral")
     extra_args = {} if extra_args is None else extra_args
     s_in = x.new_ones([x.shape[0]])
     sigma_fn = lambda t: t.neg().exp()
     t_fn = lambda sigma: sigma.log().neg()
 
     for i in trange(len(sigmas) - 1, disable=disable):
+        # import pdb; pdb.set_trace()
         denoised = model(x, sigmas[i] * s_in, **extra_args)
         sigma_down, sigma_up = get_ancestral_step(sigmas[i], sigmas[i + 1], eta=eta)
         if callback is not None:

--- a/src/ldm/models/diffusion/ddim.py
+++ b/src/ldm/models/diffusion/ddim.py
@@ -6,6 +6,8 @@ import numpy as np
 from tqdm import tqdm
 from functools import partial
 
+from helpers.device import choose_torch_device
+
 from ldm.modules.diffusionmodules.util import make_ddim_sampling_parameters, make_ddim_timesteps, noise_like, \
     extract_into_tensor
 
@@ -16,11 +18,12 @@ class DDIMSampler(object):
         self.model = model
         self.ddpm_num_timesteps = model.num_timesteps
         self.schedule = schedule
+        self.device = choose_torch_device()
 
     def register_buffer(self, name, attr):
         if type(attr) == torch.Tensor:
-            if attr.device != torch.device("cuda"):
-                attr = attr.to(torch.device("cuda"))
+            if attr.device != torch.device(self.device):
+                attr = attr.to(dtype=torch.float32, device=torch.device(self.device))
         setattr(self, name, attr)
 
     def make_schedule(self, ddim_num_steps, ddim_discretize="uniform", ddim_eta=0., verbose=True):

--- a/src/ldm/modules/attention.py
+++ b/src/ldm/modules/attention.py
@@ -5,6 +5,8 @@ import torch
 import torch.nn.functional as F
 from torch import nn, einsum
 from einops import rearrange, repeat
+import psutil
+from typing import Callable, Optional
 
 from ldm.modules.diffusionmodules.util import checkpoint
 
@@ -168,59 +170,133 @@ class CrossAttention(nn.Module):
             nn.Dropout(dropout)
         )
 
+        self.mem_total_gb = psutil.virtual_memory().total // (1 << 30)
+
+        self.cached_mem_free_total = None
+        self.attention_slice_wrangler = None
+        self.slicing_strategy_getter = None
+
+    def set_attention_slice_wrangler(self, wrangler: Optional[Callable[[nn.Module, torch.Tensor, int, int, int], torch.Tensor]]):
+        '''
+        Set custom attention calculator to be called when attention is calculated
+        :param wrangler: Callback, with args (module, suggested_attention_slice, dim, offset, slice_size),
+        which returns either the suggested_attention_slice or an adjusted equivalent.
+            `module` is the current CrossAttention module for which the callback is being invoked.
+            `suggested_attention_slice` is the default-calculated attention slice
+            `dim` is -1 if the attenion map has not been sliced, or 0 or 1 for dimension-0 or dimension-1 slicing.
+                If `dim` is >= 0, `offset` and `slice_size` specify the slice start and length.
+
+        Pass None to use the default attention calculation.
+        :return:
+        '''
+        self.attention_slice_wrangler = wrangler
+
+    def set_slicing_strategy_getter(self, getter: Optional[Callable[[nn.Module], tuple[int,int]]]):
+        self.slicing_strategy_getter = getter
+
+    def cache_free_memory_count(self, device):
+        self.cached_mem_free_total = get_mem_free_total(device)
+        print("free cuda memory: ", self.cached_mem_free_total)
+
+    def clear_cached_free_memory_count(self):
+        self.cached_mem_free_total = None
+
+    def einsum_lowest_level(self, q, k, v, dim, offset, slice_size):
+        # calculate attention scores
+        attention_scores = einsum('b i d, b j d -> b i j', q, k)
+        # calculate attention slice by taking the best scores for each latent pixel
+        default_attention_slice = attention_scores.softmax(dim=-1, dtype=attention_scores.dtype)
+        attention_slice_wrangler = self.attention_slice_wrangler
+        if attention_slice_wrangler is not None:
+            attention_slice = attention_slice_wrangler(self, default_attention_slice, dim, offset, slice_size)
+        else:
+            attention_slice = default_attention_slice
+
+        return einsum('b i j, b j d -> b i d', attention_slice, v)
+
+    def einsum_op_slice_dim0(self, q, k, v, slice_size):
+        r = torch.zeros(q.shape[0], q.shape[1], v.shape[2], device=q.device, dtype=q.dtype)
+        for i in range(0, q.shape[0], slice_size):
+            end = i + slice_size
+            r[i:end] = self.einsum_lowest_level(q[i:end], k[i:end], v[i:end], dim=0, offset=i, slice_size=slice_size)
+        return r
+
+    def einsum_op_slice_dim1(self, q, k, v, slice_size):
+        r = torch.zeros(q.shape[0], q.shape[1], v.shape[2], device=q.device, dtype=q.dtype)
+        for i in range(0, q.shape[1], slice_size):
+            end = i + slice_size
+            r[:, i:end] = self.einsum_lowest_level(q[:, i:end], k, v, dim=1, offset=i, slice_size=slice_size)
+        return r
+
+    def einsum_op_mps_v1(self, q, k, v):
+        if q.shape[1] <= 4096: # (512x512) max q.shape[1]: 4096
+            return self.einsum_lowest_level(q, k, v, None, None, None)
+        else:
+            slice_size = math.floor(2**30 / (q.shape[0] * q.shape[1]))
+            return self.einsum_op_slice_dim1(q, k, v, slice_size)
+
+    def einsum_op_mps_v2(self, q, k, v):
+        if self.mem_total_gb > 8 and q.shape[1] <= 4096:
+            return self.einsum_lowest_level(q, k, v, None, None, None)
+        else:
+            return self.einsum_op_slice_dim0(q, k, v, 1)
+
+    def einsum_op_tensor_mem(self, q, k, v, max_tensor_mb):
+        size_mb = q.shape[0] * q.shape[1] * k.shape[1] * q.element_size() // (1 << 20)
+        if size_mb <= max_tensor_mb:
+            return self.einsum_lowest_level(q, k, v, None, None, None)
+        div = 1 << int((size_mb - 1) / max_tensor_mb).bit_length()
+        if div <= q.shape[0]:
+            return self.einsum_op_slice_dim0(q, k, v, q.shape[0] // div)
+        return self.einsum_op_slice_dim1(q, k, v, max(q.shape[1] // div, 1))
+
+    def einsum_op_cuda(self, q, k, v):
+        # check if we already have a slicing strategy (this should only happen during cross-attention controlled generation)
+        slicing_strategy_getter = self.slicing_strategy_getter
+        if slicing_strategy_getter is not None:
+            (dim, slice_size) = slicing_strategy_getter(self)
+            if dim is not None:
+                # print("using saved slicing strategy with dim", dim, "slice size", slice_size)
+                if dim == 0:
+                    return self.einsum_op_slice_dim0(q, k, v, slice_size)
+                elif dim == 1:
+                    return self.einsum_op_slice_dim1(q, k, v, slice_size)
+
+        # fallback for when there is no saved strategy, or saved strategy does not slice
+        mem_free_total = self.cached_mem_free_total or get_mem_free_total(q.device)
+        # Divide factor of safety as there's copying and fragmentation
+        return self.einsum_op_tensor_mem(q, k, v, mem_free_total / 3.3 / (1 << 20))
+
+
+    def get_attention_mem_efficient(self, q, k, v):
+        if q.device.type == 'cuda':
+            #print("in get_attention_mem_efficient with q shape", q.shape, ", k shape", k.shape, ", free memory is", get_mem_free_total(q.device))
+            return self.einsum_op_cuda(q, k, v)
+
+        if q.device.type == 'mps':
+            if self.mem_total_gb >= 32:
+                return self.einsum_op_mps_v1(q, k, v)
+            return self.einsum_op_mps_v2(q, k, v)
+
+        # Smaller slices are faster due to L2/L3/SLC caches.
+        # Tested on i7 with 8MB L3 cache.
+        return self.einsum_op_tensor_mem(q, k, v, 32)
+
     def forward(self, x, context=None, mask=None):
         h = self.heads
 
-        q_in = self.to_q(x)
+        q = self.to_q(x)
         context = default(context, x)
-        k_in = self.to_k(context)
-        v_in = self.to_v(context)
+        k = self.to_k(context) * self.scale
+        v = self.to_v(context)
         del context, x
 
-        q, k, v = map(lambda t: rearrange(t, 'b n (h d) -> (b h) n d', h=h), (q_in, k_in, v_in))
-        del q_in, k_in, v_in
+        q, k, v = map(lambda t: rearrange(t, 'b n (h d) -> (b h) n d', h=h), (q, k, v))
 
-        r1 = torch.zeros(q.shape[0], q.shape[1], v.shape[2], device=q.device)
+        r = self.get_attention_mem_efficient(q, k, v)
 
-        stats = torch.cuda.memory_stats(q.device)
-        mem_active = stats['active_bytes.all.current']
-        mem_reserved = stats['reserved_bytes.all.current']
-        mem_free_cuda, _ = torch.cuda.mem_get_info(torch.cuda.current_device())
-        mem_free_torch = mem_reserved - mem_active
-        mem_free_total = mem_free_cuda + mem_free_torch
-
-        gb = 1024 ** 3
-        tensor_size = q.shape[0] * q.shape[1] * k.shape[1] * 4
-        mem_required = tensor_size * 2.5
-        steps = 1
-
-        if mem_required > mem_free_total:
-            steps = 2**(math.ceil(math.log(mem_required / mem_free_total, 2)))
-            # print(f"Expected tensor size:{tensor_size/gb:0.1f}GB, cuda free:{mem_free_cuda/gb:0.1f}GB "
-            #       f"torch free:{mem_free_torch/gb:0.1f} total:{mem_free_total/gb:0.1f} steps:{steps}")
-
-        if steps > 64:
-            max_res = math.floor(math.sqrt(math.sqrt(mem_free_total / 2.5)) / 8) * 64
-            raise RuntimeError(f'Not enough memory, use lower resolution (max approx. {max_res}x{max_res}). '
-                               f'Need: {mem_required/64/gb:0.1f}GB free, Have:{mem_free_total/gb:0.1f}GB free')
-
-        slice_size = q.shape[1] // steps if (q.shape[1] % steps) == 0 else q.shape[1]
-        for i in range(0, q.shape[1], slice_size):
-            end = i + slice_size
-            s1 = einsum('b i d, b j d -> b i j', q[:, i:end], k) * self.scale
-
-            s2 = s1.softmax(dim=-1)
-            del s1
-
-            r1[:, i:end] = einsum('b i j, b j d -> b i d', s2, v)
-            del s2
-
-        del q, k, v
-
-        r2 = rearrange(r1, '(b h) n d -> b n (h d)', h=h)
-        del r1
-
-        return self.to_out(r2)
+        hidden_states = rearrange(r, '(b h) n d -> b n (h d)', h=h)
+        return self.to_out(hidden_states)
 
 
 class BasicTransformerBlock(nn.Module):
@@ -239,9 +315,10 @@ class BasicTransformerBlock(nn.Module):
         return checkpoint(self._forward, (x, context), self.parameters(), self.checkpoint)
 
     def _forward(self, x, context=None):
-        x = self.attn1(self.norm1(x)) + x
-        x = self.attn2(self.norm2(x), context=context) + x
-        x = self.ff(self.norm3(x)) + x
+        x = x.contiguous() if x.device.type == 'mps' else x
+        x += self.attn1(self.norm1(x.clone()))
+        x += self.attn2(self.norm2(x.clone()), context=context)
+        x += self.ff(self.norm3(x.clone()))
         return x
 
 

--- a/src/ldm/modules/diffusionmodules/model.py
+++ b/src/ldm/modules/diffusionmodules/model.py
@@ -5,6 +5,7 @@ import torch
 import torch.nn as nn
 import numpy as np
 from einops import rearrange
+import psutil
 
 from ldm.util import instantiate_from_config
 from ldm.modules.attention import LinearAttention
@@ -207,22 +208,29 @@ class AttnBlock(nn.Module):
         del k1
 
         h_ = torch.zeros_like(k, device=q.device)
+        
+        if q.device.type == 'cuda':
+            stats = torch.cuda.memory_stats(q.device)
+            mem_active = stats['active_bytes.all.current']
+            mem_reserved = stats['reserved_bytes.all.current']
+            mem_free_cuda, _ = torch.cuda.mem_get_info(torch.cuda.current_device())
+            mem_free_torch = mem_reserved - mem_active
+            mem_free_total = mem_free_cuda + mem_free_torch
 
-        stats = torch.cuda.memory_stats(q.device)
-        mem_active = stats['active_bytes.all.current']
-        mem_reserved = stats['reserved_bytes.all.current']
-        mem_free_cuda, _ = torch.cuda.mem_get_info(torch.cuda.current_device())
-        mem_free_torch = mem_reserved - mem_active
-        mem_free_total = mem_free_cuda + mem_free_torch
+            tensor_size = q.shape[0] * q.shape[1] * k.shape[2] * 4
+            mem_required = tensor_size * 2.5
+            steps = 1
 
-        tensor_size = q.shape[0] * q.shape[1] * k.shape[2] * 4
-        mem_required = tensor_size * 2.5
-        steps = 1
+            if mem_required > mem_free_total:
+                steps = 2**(math.ceil(math.log(mem_required / mem_free_total, 2)))
 
-        if mem_required > mem_free_total:
-            steps = 2**(math.ceil(math.log(mem_required / mem_free_total, 2)))
+            slice_size = q.shape[1] // steps if (q.shape[1] % steps) == 0 else q.shape[1]
+        else:
+            if psutil.virtual_memory().available / (1024**3) < 12:
+                slice_size = 1
+            else:
+                slice_size = min(q.shape[1], math.floor(2**30 / (q.shape[0] * q.shape[1])))
 
-        slice_size = q.shape[1] // steps if (q.shape[1] % steps) == 0 else q.shape[1]
         for i in range(0, q.shape[1], slice_size):
             end = i + slice_size
 

--- a/src/ldm/modules/encoders/modules.py
+++ b/src/ldm/modules/encoders/modules.py
@@ -8,6 +8,7 @@ import kornia
 
 from ldm.modules.x_transformer import Encoder, TransformerWrapper  # TODO: can we directly rely on lucidrains code and simply add this as a reuirement? --> test
 
+from helpers.device import choose_torch_device
 
 class AbstractEncoder(nn.Module):
     def __init__(self):
@@ -35,7 +36,7 @@ class ClassEmbedder(nn.Module):
 
 class TransformerEmbedder(AbstractEncoder):
     """Some transformer encoder layers"""
-    def __init__(self, n_embed, n_layer, vocab_size, max_seq_len=77, device="cuda"):
+    def __init__(self, n_embed, n_layer, vocab_size, max_seq_len=77, device=choose_torch_device()):
         super().__init__()
         self.device = device
         self.transformer = TransformerWrapper(num_tokens=vocab_size, max_seq_len=max_seq_len,
@@ -52,7 +53,7 @@ class TransformerEmbedder(AbstractEncoder):
 
 class BERTTokenizer(AbstractEncoder):
     """ Uses a pretrained BERT tokenizer by huggingface. Vocab size: 30522 (?)"""
-    def __init__(self, device="cuda", vq_interface=True, max_length=77):
+    def __init__(self, device=choose_torch_device(), vq_interface=True, max_length=77):
         super().__init__()
         from transformers import BertTokenizerFast  # TODO: add to reuquirements
         self.tokenizer = BertTokenizerFast.from_pretrained("bert-base-uncased")
@@ -80,7 +81,7 @@ class BERTTokenizer(AbstractEncoder):
 class BERTEmbedder(AbstractEncoder):
     """Uses the BERT tokenizr model and add some transformer encoder layers"""
     def __init__(self, n_embed, n_layer, vocab_size=30522, max_seq_len=77,
-                 device="cuda",use_tokenizer=True, embedding_dropout=0.0):
+                 device=choose_torch_device(),use_tokenizer=True, embedding_dropout=0.0):
         super().__init__()
         self.use_tknz_fn = use_tokenizer
         if self.use_tknz_fn:
@@ -136,7 +137,7 @@ class SpatialRescaler(nn.Module):
 
 class FrozenCLIPEmbedder(AbstractEncoder):
     """Uses the CLIP transformer encoder for text (from Hugging Face)"""
-    def __init__(self, version="openai/clip-vit-large-patch14", device="cuda", max_length=77):
+    def __init__(self, version="openai/clip-vit-large-patch14", device=choose_torch_device(), max_length=77):
         super().__init__()
         self.tokenizer = CLIPTokenizer.from_pretrained(version)
         self.transformer = CLIPTextModel.from_pretrained(version)
@@ -166,7 +167,7 @@ class FrozenCLIPTextEmbedder(nn.Module):
     """
     Uses the CLIP transformer encoder for text.
     """
-    def __init__(self, version='ViT-L/14', device="cuda", max_length=77, n_repeat=1, normalize=True):
+    def __init__(self, version='ViT-L/14', device=choose_torch_device(), max_length=77, n_repeat=1, normalize=True):
         super().__init__()
         self.model, _ = clip.load(version, jit=False, device="cpu")
         self.device = device
@@ -202,7 +203,7 @@ class FrozenClipImageEmbedder(nn.Module):
             self,
             model,
             jit=False,
-            device='cuda' if torch.cuda.is_available() else 'cpu',
+            device=choose_torch_device(),
             antialias=False,
         ):
         super().__init__()

--- a/src/py3d_tools.py
+++ b/src/py3d_tools.py
@@ -505,6 +505,9 @@ class Transform3d:
 
     def cuda(self) -> "Transform3d":
         return self.to("cuda")
+    
+    def mps(self) -> "Transform3d":
+        return self.to("mps")
 
 class Translate(Transform3d):
     def __init__(
@@ -745,6 +748,9 @@ class TensorProperties(nn.Module):
     # pyre-fixme[14]: `cuda` overrides method defined in `Module` inconsistently.
     def cuda(self, device: Optional[int] = None) -> "TensorProperties":
         return self.to(f"cuda:{device}" if device is not None else "cuda")
+    
+    def mps(self) -> "TensorProperties":
+        return self.to("mps")
 
     def clone(self, other) -> "TensorProperties":
         """
@@ -1153,7 +1159,7 @@ class CamerasBase(TensorProperties):
 
         kwargs = {}
 
-        if not isinstance(index, (int, list, torch.LongTensor, torch.cuda.LongTensor)):
+        if not isinstance(index, (int, list, torch.LongTensor, torch.LongTensor)):
             msg = "Invalid index type, expected int, List[int] or torch.LongTensor; got %r"
             raise ValueError(msg % type(index))
 

--- a/src/rank_images.py
+++ b/src/rank_images.py
@@ -9,12 +9,14 @@ import torch
 from simulacra_fit_linear_model import AestheticMeanPredictionLinearModel
 from CLIP import clip
 
+from helpers.device import choose_torch_device
+
 parser = ArgumentParser()
 parser.add_argument("directory")
 parser.add_argument("-t", "--top-n", default=50)
 args = parser.parse_args()
 
-device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
+device = torch.device(choose_torch_device())
 
 clip_model_name = 'ViT-B/16'
 clip_model = clip.load(clip_model_name, jit=False, device=device)[0]

--- a/src/simulacra_compute_embeddings.py
+++ b/src/simulacra_compute_embeddings.py
@@ -15,6 +15,7 @@ from torch.utils import data
 import torchvision.transforms as transforms
 from tqdm import tqdm
 
+from helpers.device import choose_torch_device
 from CLIP import clip
 
 
@@ -69,7 +70,7 @@ def main():
     if args.device:
         device = torch.device(device)
     else:
-        device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+        device = torch.device(choose_torch_device())
     print('Using device:', device)
 
     clip_model, clip_tf = clip.load(args.clip_model, device=device, jit=False)


### PR DESCRIPTION
- Change occurrences (hardcodings, default arguments) of "cuda" to accept other torch devices ("mps", "cpu")
- Auto-detect and set torch device when running on appropriate hardware
- Don't use unsupported autocast when running on MPS, and always use full-precision (float32)
- Port CrossAttention optimizations from InvokeAI stable diffusion frontend, which dramatically speed up inference
- Fix seed instability caused by torch.randn not using the global seed on MPS hardware
- Various other bugfixes from (https://github.com/CompVis/stable-diffusion/issues/25)